### PR TITLE
Fix "TypeError: execve() arg 3 contains a non-string value" on running a create-repository hook

### DIFF
--- a/submin/models/repository.py
+++ b/submin/models/repository.py
@@ -78,7 +78,7 @@ class Repository(object):
 	def add(vcs_type, name, session_user):
 		vcs = models.vcs.get(vcs_type, "repository")
 		vcs.add(name)
-		trigger_hook('repository-create', admin_username=session_user,
+		trigger_hook('repository-create', admin_username=unicode(session_user),
 			repositoryname=name, vcs_type=vcs_type)
 
 	def __init__(self, repositoryname, vcs_type):


### PR DESCRIPTION
See http://stackoverflow.com/q/28651164/648265
